### PR TITLE
Don't crash when credentials.yaml or clouds.yaml files don't exist

### DIFF
--- a/lib/local_juju_users.py
+++ b/lib/local_juju_users.py
@@ -201,13 +201,21 @@ def save_base64_to_file(base64_string, file_path):
 def read_clouds_file(user):
     """Return the clouds.yaml as base64 encoded string."""
     clouds_file = "/home/{}/.local/share/juju/clouds.yaml".format(user)
-    return encode_file_to_base64(clouds_file)
+    try:
+        return encode_file_to_base64(clouds_file)
+    except FileNotFoundError:
+        # return dummy empty clouds in the expected format
+        return base64.b64encode(b"clouds: {}")
 
 
 def read_credentials_file(user):
     """Return the clouds.yaml as base64 encoded string."""
     credentials_file = "/home/{}/.local/share/juju/credentials.yaml".format(user)
-    return encode_file_to_base64(credentials_file)
+    try:
+        return encode_file_to_base64(credentials_file)
+    except FileNotFoundError:
+        # return dummy empty credentials in the expected format
+        return base64.b64encode(b"credentials: {}")
 
 
 def save_clouds_file(user, clouds):

--- a/src/charm.py
+++ b/src/charm.py
@@ -265,9 +265,10 @@ class LocalJujuUsersCharm(ops.charm.CharmBase):
         # on the leader load admin's clouds.yaml and credentials.yaml files so that they can be distributed to other users
         if self.unit.is_leader():
             credentials = read_credentials_file(self.model.config["juju-admin-unix-account"])
-            clouds = read_clouds_file(self.model.config["juju-admin-unix-account"])
             if self._get_peer_data("credentials") != credentials:
                 self._set_peer_data("credentials", credentials)
+
+            clouds = read_clouds_file(self.model.config["juju-admin-unix-account"])
             if self._get_peer_data("clouds") != clouds:
                 self._set_peer_data("clouds", clouds)
 


### PR DESCRIPTION
Fixes issue #4.